### PR TITLE
fix: compare mark names in equalYTextPText

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -960,7 +960,7 @@ const equalYTextPText = (ytext, ptexts) => {
     delta.every(/** @type {(d:any,i:number) => boolean} */ (d, i) =>
       d.insert === /** @type {any} */ (ptexts[i]).text &&
       object.keys(d.attributes || {}).length === ptexts[i].marks.length &&
-      object.every(d.attributes, (attr, yattrname) => {
+      object.every(d.attributes, (attr, /** @type {string} */ yattrname) => {
         const markname = yattr2markname(yattrname)
         const pmarks = ptexts[i].marks
 

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -963,6 +963,15 @@ const equalYTextPText = (ytext, ptexts) => {
       object.every(d.attributes, (attr, yattrname) => {
         const markname = yattr2markname(yattrname)
         const pmarks = ptexts[i].marks
+
+        const pmark = pmarks.find(/** @param {any} mark */ mark => mark.type.name === markname)
+
+        // Ensure the pmark is present in the ptexts before checking equality. When replacing a mark with another mark
+        // the pmark will be missing from the ptexts and the equalAttrs will throw an error.
+        if (!pmark) {
+          return false
+        }
+
         return equalAttrs(attr, pmarks.find(/** @param {any} mark */ mark => mark.type.name === markname)?.attrs)
       })
     )

--- a/tests/y-tiptap.test.js
+++ b/tests/y-tiptap.test.js
@@ -309,6 +309,64 @@ export const testInsertDuplication = (_tc) => {
   t.assert(yxml1.toString() === '<paragraph>1122</paragraph><paragraph></paragraph>')
 }
 
+export const testReplaceBoldWithCode = (_tc) => {
+  const ydoc = new Y.Doc()
+  const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment)
+  const view = createNewProsemirrorView(ydoc) // This already includes ySyncPlugin
+
+  // Insert a paragraph with some text
+  view.dispatch(
+    view.state.tr.insert(
+      0,
+      schema.node(
+        'paragraph',
+        undefined,
+        schema.text('test')
+      )
+    )
+  )
+
+  view.dispatch(view.state.tr.addMark(1, 5, schema.mark('strong')))
+
+  t.compare(
+    JSON.parse(JSON.stringify(view.state.doc.toJSON().content[0].content)),
+    [{
+      type: 'text',
+      marks: [{ type: 'strong' }],
+      text: 'test'
+    }],
+    'invalid view state'
+  )
+
+  t.compare(
+    yXmlFragment.get(0).toString(),
+    '<paragraph><strong>test</strong></paragraph>',
+    'invalid ydoc state'
+  )
+
+  view.dispatch(
+    view.state.tr
+      .removeMark(1, 5, schema.mark('strong'))
+      .addMark(1, 5, schema.mark('code'))
+  )
+
+  t.compare(
+    JSON.parse(JSON.stringify(view.state.doc.toJSON().content[0].content)),
+    [{
+      type: 'text',
+      marks: [{ type: 'code' }],
+      text: 'test'
+    }],
+    'invalid view state'
+  )
+
+  t.compare(
+    yXmlFragment.get(0).toString(),
+    '<paragraph><code>test</code></paragraph>',
+    'invalid ydoc state'
+  )
+}
+
 export const testAddToHistory = (_tc) => {
   const ydoc = new Y.Doc()
   const view = createNewProsemirrorViewWithUndoManager(ydoc)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2018",
+    "skipLibCheck": true,
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
Attribution to @aonikov opening this in the y-prosemirror repository https://github.com/yjs/y-prosemirror/pull/198