### PR TITLE
Handle stale cursor meta transactions

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -20,38 +20,68 @@ import * as eventloop from 'lib0/eventloop'
  */
 let viewsToUpdate = null
 
-/**
- * Dispatch one queued plugin meta entry for a view.
- *
- * @param {EditorView} view
- * @param {any} key
- * @param {any} value
- */
-const applyMeta = (view, key, value) => {
-  const syncState = ySyncPluginKey.getState(view.state)
-  if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
-    const tr = view.state.tr
-    tr.setMeta(key, value)
-    view.dispatch(tr)
+class MetaEntry {
+  /**
+   * @param {EditorView} view
+   * @param {any} key
+   * @param {any} value
+   */
+  constructor (view, key, value) {
+    this.view = view
+    this.key = key
+    this.value = value
+  }
+
+  apply () {
+    const syncState = ySyncPluginKey.getState(this.view.state)
+    if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
+      const tr = this.view.state.tr
+      tr.setMeta(this.key, this.value)
+      this.view.dispatch(tr)
+    }
   }
 }
 
-/**
- * Convert the queued meta updates into a stable ordered list so stale work can
- * be retried from the point where dispatch failed.
- *
- * @return {Array<[EditorView, any, any]>}
- */
-const getMetaEntries = () => {
-  const ups = /** @type {Map<EditorView, Map<any, any>>} */ (viewsToUpdate)
-  viewsToUpdate = null
-  const entries = []
-  ups.forEach((metas, view) => {
-    metas.forEach((value, key) => {
-      entries.push([view, key, value])
+class MetaEntriesQueue {
+  /**
+   * @param {Array<MetaEntry>} [entries=[]]
+   */
+  constructor (entries = []) {
+    this.entries = entries
+  }
+
+  /**
+   * @return {MetaEntry|undefined}
+   */
+  getFirst () {
+    return this.entries[0]
+  }
+
+  /**
+   * @return {MetaEntry|undefined}
+   */
+  dequeueFirst () {
+    return this.entries.shift()
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isEmpty () {
+    return this.entries.length === 0
+  }
+
+  static fromViewsToUpdate () {
+    const ups = /** @type {Map<EditorView, Map<any, any>>} */ (viewsToUpdate)
+    viewsToUpdate = null
+    const entries = []
+    ups.forEach((metas, view) => {
+      metas.forEach((value, key) => {
+        entries.push(new MetaEntry(view, key, value))
+      })
     })
-  })
-  return entries
+    return new MetaEntriesQueue(entries)
+  }
 }
 
 /**
@@ -65,32 +95,33 @@ const getMetaEntries = () => {
  * on retry, we drop that entry and continue with the rest of the queue instead
  * of retrying forever or crashing the editor.
  *
- * @param {Array<[EditorView, any, any]>} [metaEntries=getMetaEntries()]
+ * @param {MetaEntriesQueue} [metaEntries=MetaEntriesQueue.fromViewsToUpdate()]
  * @param {boolean} [isRetry=false]
  */
-const updateMetas = (metaEntries = getMetaEntries(), isRetry = false) => {
-  for (let index = 0; index < metaEntries.length; index++) {
-    const [view, key, value] = metaEntries[index]
+const updateMetas = (metaEntries = MetaEntriesQueue.fromViewsToUpdate(), isRetry = false) => {
+  let isFirst = true
+  while (!metaEntries.isEmpty()) {
+    const metaEntry = metaEntries.getFirst()
     try {
-      applyMeta(view, key, value)
+      metaEntry.apply()
     } catch (err) {
       // ProseMirror throws a RangeError when this transaction was created from
       // an older state and another transaction changed the document before this
       // meta-only dispatch was applied ("Applying a mismatched transaction").
       if (err instanceof RangeError) {
-        const remainingMetaEntries = metaEntries.slice(
-          // On retry, skip the first entry because it has already failed once.
-          // This prevents an infinite reschedule loop for a persistently stale
-          // awareness update while still letting the rest of the queue flush.
-          Math.max(isRetry ? 1 : 0, index),
-        )
-        if (remainingMetaEntries.length > 0) {
-          eventloop.timeout(0, () => updateMetas(remainingMetaEntries, true))
+        if (isRetry && isFirst) {
+          // Drop the repeatedly stale entry so the queue can continue flushing.
+          metaEntries.dequeueFirst()
+        }
+        if (!metaEntries.isEmpty()) {
+          eventloop.timeout(0, () => updateMetas(metaEntries, true))
         }
         return
       }
       throw err
     }
+    isFirst = false
+    metaEntries.dequeueFirst()
   }
 }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -46,6 +46,8 @@ const applyMetas = (view, metas, retry = true) => {
     } catch (err) {
       if (err instanceof RangeError && err.message === 'Applying a mismatched transaction') {
         if (retry) {
+          // Retry once with `retry = false` so a persistent mismatch cannot
+          // reschedule itself forever.
           // Recreate the meta-only transaction from the latest editor state.
           eventloop.timeout(0, () => applyMetas(view, metas, false))
         }

--- a/src/lib.js
+++ b/src/lib.js
@@ -20,18 +20,32 @@ import * as eventloop from 'lib0/eventloop'
  */
 let viewsToUpdate = null
 
+const applyMetas = (view, metas, retry = true) => {
+  const syncState = ySyncPluginKey.getState(view.state)
+  if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
+    const tr = view.state.tr
+    metas.forEach((val, key) => {
+      tr.setMeta(key, val)
+    })
+    try {
+      view.dispatch(tr)
+    } catch (err) {
+      if (err instanceof RangeError && err.message === 'Applying a mismatched transaction') {
+        if (retry) {
+          eventloop.timeout(0, () => applyMetas(view, metas, false))
+        }
+        return
+      }
+      throw err
+    }
+  }
+}
+
 const updateMetas = () => {
   const ups = /** @type {Map<EditorView, Map<any, any>>} */ (viewsToUpdate)
   viewsToUpdate = null
   ups.forEach((metas, view) => {
-    const tr = view.state.tr
-    const syncState = ySyncPluginKey.getState(view.state)
-    if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
-      metas.forEach((val, key) => {
-        tr.setMeta(key, val)
-      })
-      view.dispatch(tr)
-    }
+    applyMetas(view, metas)
   })
 }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -44,7 +44,10 @@ const applyMetas = (view, metas, retry = true) => {
     try {
       view.dispatch(tr)
     } catch (err) {
-      if (err instanceof RangeError && err.message === 'Applying a mismatched transaction') {
+      // ProseMirror throws a RangeError when this transaction was created from
+      // an older state and another transaction changed the document before this
+      // meta-only dispatch was applied ("Applying a mismatched transaction").
+      if (err instanceof RangeError) {
         if (retry) {
           // Retry once with `retry = false` so a persistent mismatch cannot
           // reschedule itself forever.

--- a/src/lib.js
+++ b/src/lib.js
@@ -20,6 +20,20 @@ import * as eventloop from 'lib0/eventloop'
  */
 let viewsToUpdate = null
 
+/**
+ * Dispatch queued plugin metadata for a view, retrying once if the transaction
+ * became stale while waiting in the async awareness-update queue.
+ *
+ * Cursor awareness updates are decoration-only refreshes. If a real document
+ * transaction lands before this queued meta transaction is applied, ProseMirror
+ * will reject the older transaction with "Applying a mismatched transaction".
+ * In that case we rebuild the meta transaction from the latest state once, and
+ * stop after a second mismatch instead of crashing the editor.
+ *
+ * @param {EditorView} view
+ * @param {Map<any, any>} metas
+ * @param {boolean} [retry=true]
+ */
 const applyMetas = (view, metas, retry = true) => {
   const syncState = ySyncPluginKey.getState(view.state)
   if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
@@ -32,6 +46,7 @@ const applyMetas = (view, metas, retry = true) => {
     } catch (err) {
       if (err instanceof RangeError && err.message === 'Applying a mismatched transaction') {
         if (retry) {
+          // Recreate the meta-only transaction from the latest editor state.
           eventloop.timeout(0, () => applyMetas(view, metas, false))
         }
         return
@@ -52,6 +67,7 @@ const updateMetas = () => {
 export const setMeta = (view, key, value) => {
   if (!viewsToUpdate) {
     viewsToUpdate = new Map()
+    // Awareness listeners can fire in bursts, so batch them into one tick.
     eventloop.timeout(0, updateMetas)
   }
   map.setIfUndefined(viewsToUpdate, view, map.create).set(key, value)

--- a/src/lib.js
+++ b/src/lib.js
@@ -21,52 +21,77 @@ import * as eventloop from 'lib0/eventloop'
 let viewsToUpdate = null
 
 /**
- * Dispatch queued plugin metadata for a view, retrying once if the transaction
- * became stale while waiting in the async awareness-update queue.
- *
- * Cursor awareness updates are decoration-only refreshes. If a real document
- * transaction lands before this queued meta transaction is applied, ProseMirror
- * will reject the older transaction with "Applying a mismatched transaction".
- * In that case we rebuild the meta transaction from the latest state once, and
- * stop after a second mismatch instead of crashing the editor.
+ * Dispatch one queued plugin meta entry for a view.
  *
  * @param {EditorView} view
- * @param {Map<any, any>} metas
- * @param {boolean} [retry=true]
+ * @param {any} key
+ * @param {any} value
  */
-const applyMetas = (view, metas, retry = true) => {
+const applyMeta = (view, key, value) => {
   const syncState = ySyncPluginKey.getState(view.state)
   if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
     const tr = view.state.tr
-    metas.forEach((val, key) => {
-      tr.setMeta(key, val)
+    tr.setMeta(key, value)
+    view.dispatch(tr)
+  }
+}
+
+/**
+ * Convert the queued meta updates into a stable ordered list so stale work can
+ * be retried from the point where dispatch failed.
+ *
+ * @return {Array<[EditorView, any, any]>}
+ */
+const getMetaEntries = () => {
+  const ups = /** @type {Map<EditorView, Map<any, any>>} */ (viewsToUpdate)
+  viewsToUpdate = null
+  const entries = []
+  ups.forEach((metas, view) => {
+    metas.forEach((value, key) => {
+      entries.push([view, key, value])
     })
+  })
+  return entries
+}
+
+/**
+ * Dispatch queued plugin metadata in order, retrying only the remaining
+ * entries if a transaction becomes stale while the async queue is flushing.
+ *
+ * Cursor awareness updates are decoration-only refreshes. If a real document
+ * transaction lands before one of these queued meta transactions is applied,
+ * ProseMirror can reject it with a RangeError. In that case we reschedule the
+ * remaining entries on the next tick. If the first remaining entry fails again
+ * on retry, we drop that entry and continue with the rest of the queue instead
+ * of retrying forever or crashing the editor.
+ *
+ * @param {Array<[EditorView, any, any]>} [metaEntries=getMetaEntries()]
+ * @param {boolean} [isRetry=false]
+ */
+const updateMetas = (metaEntries = getMetaEntries(), isRetry = false) => {
+  for (let index = 0; index < metaEntries.length; index++) {
+    const [view, key, value] = metaEntries[index]
     try {
-      view.dispatch(tr)
+      applyMeta(view, key, value)
     } catch (err) {
       // ProseMirror throws a RangeError when this transaction was created from
       // an older state and another transaction changed the document before this
       // meta-only dispatch was applied ("Applying a mismatched transaction").
       if (err instanceof RangeError) {
-        if (retry) {
-          // Retry once with `retry = false` so a persistent mismatch cannot
-          // reschedule itself forever.
-          // Recreate the meta-only transaction from the latest editor state.
-          eventloop.timeout(0, () => applyMetas(view, metas, false))
+        const remainingMetaEntries = metaEntries.slice(
+          // On retry, skip the first entry because it has already failed once.
+          // This prevents an infinite reschedule loop for a persistently stale
+          // awareness update while still letting the rest of the queue flush.
+          Math.max(isRetry ? 1 : 0, index),
+        )
+        if (remainingMetaEntries.length > 0) {
+          eventloop.timeout(0, () => updateMetas(remainingMetaEntries, true))
         }
         return
       }
       throw err
     }
   }
-}
-
-const updateMetas = () => {
-  const ups = /** @type {Map<EditorView, Map<any, any>>} */ (viewsToUpdate)
-  viewsToUpdate = null
-  ups.forEach((metas, view) => {
-    applyMetas(view, metas)
-  })
 }
 
 export const setMeta = (view, key, value) => {

--- a/tests/y-tiptap.test.js
+++ b/tests/y-tiptap.test.js
@@ -11,6 +11,8 @@ import {
   prosemirrorJSONToYXmlFragment,
   redo,
   undo,
+  yCursorPlugin,
+  yCursorPluginKey,
   yDocToProsemirrorJSON,
   ySyncPlugin,
   ySyncPluginKey,
@@ -470,6 +472,49 @@ export const testInitialCursorPosition2 = async (_tc) => {
   console.log('anchor', view.state.selection.anchor)
   t.assert(view.state.selection.anchor === 1)
   t.assert(view.state.selection.head === 1)
+}
+
+export const testStaleAwarenessTransactions = async (_tc) => {
+  const ydoc = new Y.Doc()
+  const awareness = new Awareness(ydoc)
+  let insertedContent = false
+  const view = new EditorView(null, {
+    // @ts-ignore
+    state: EditorState.create({
+      schema,
+      plugins: [
+        ySyncPlugin(ydoc.get('prosemirror', Y.XmlFragment)),
+        yCursorPlugin(awareness)
+      ]
+    })
+  })
+
+  const applyTransaction = tr => {
+    const newState = view.state.apply(tr)
+    view.updateState(newState)
+  }
+
+  view.setProps({
+    dispatchTransaction: tr => {
+      const cursorMeta = tr.getMeta(yCursorPluginKey)
+
+      if (!insertedContent && cursorMeta && cursorMeta.awarenessUpdated) {
+        insertedContent = true
+        applyTransaction(view.state.tr.insertText('x', 1))
+      }
+
+      applyTransaction(tr)
+    }
+  })
+
+  awareness.setLocalStateField('user', {
+    name: 'Test User',
+    color: '#ff0000'
+  })
+
+  await promise.wait(10)
+
+  t.assert(view.state.doc.textContent === 'x', 'stale awareness transactions should not crash the editor')
 }
 
 export const testVersioning = async (_tc) => {

--- a/tests/y-tiptap.test.js
+++ b/tests/y-tiptap.test.js
@@ -500,6 +500,7 @@ export const testStaleAwarenessTransactions = async (_tc) => {
 
       if (!insertedContent && cursorMeta && cursorMeta.awarenessUpdated) {
         insertedContent = true
+        // Force the queued awareness transaction to become stale before apply.
         applyTransaction(view.state.tr.insertText('x', 1))
       }
 


### PR DESCRIPTION
## Bug
`y-tiptap` batches cursor awareness updates through `setMeta(view, yCursorPluginKey, { awarenessUpdated: true })`, and dispatches the resulting meta-only transaction asynchronously on the next tick.

That transaction can become stale before it is applied. If the editor state changes after the cursor update is queued but before the queued dispatch runs, ProseMirror rejects the old transaction with `RangeError: Applying a mismatched transaction`.

Because this path is used for cursor decoration refreshes rather than content sync, the crash is disproportionate to the actual operation.

## Why It Happened
The failure is in `src/lib.js`:
- `setMeta()` stores pending meta updates per view and schedules `updateMetas()` with `eventloop.timeout(0, ...)`
- `updateMetas()` later creates `view.state.tr`, applies the queued meta, and dispatches it
- if another transaction changes the document between queue time and dispatch time, the queued awareness transaction is no longer based on the current state
- ProseMirror then throws when applying that stale transaction

This is most visible with `awarenessUpdated` from the cursor plugin, because awareness updates are asynchronous and can race with normal document transactions.

## Reproduction
The new regression test reproduces the issue directly:
1. Create an `EditorView` with `ySyncPlugin` and `yCursorPlugin`
2. Trigger an awareness update so `yCursorPlugin` queues an async `awarenessUpdated` meta transaction
3. Before that queued transaction is applied, dispatch a document-changing transaction
4. Let the queued awareness transaction run

Before this fix, step 4 can throw `RangeError: Applying a mismatched transaction`.

The test in `tests/y-tiptap.test.js` does exactly that by intercepting `dispatchTransaction`, inserting text right before the queued `awarenessUpdated` transaction is applied, and then asserting the editor stays alive.

## Fix
- retry awareness-only cursor meta dispatches once when they fail with a mismatched transaction error
- drop the stale meta dispatch on the second mismatch instead of crashing the editor

This keeps cursor decoration refreshes best-effort without turning a stale async awareness update into a fatal editor error.

## Testing
- `npm test`
