### PR TITLE
Fix the changesets release workflow YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,7 @@ jobs:
           publish: npm run release
           createGithubReleases: false
           title: Release a new version
-          commit: chore(release): publish a new version
+          commit: "chore(release): publish a new version"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-


### PR DESCRIPTION
## Summary

Fix the release workflow syntax error in `.github/workflows/release.yml` .

## What changed

- quoted the  value passed to 
- kept the rest of the release pipeline unchanged

## Why

GitHub Actions was rejecting the workflow because the unquoted  value contained a colon, which broke YAML parsing.

## Verification

- reviewed the workflow file after the edit
- confirmed the repository is clean on the new branch