### PR TITLE
Avoid recursive npm publish during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preversion": "npm run lint && npm run dist && npm run test",
     "version": "changeset version && npm install --package-lock-only",
     "release": "npm publish --access public",
-    "publish": "npm run preversion && npm publish --access public",
+    "publish:manual": "npm run preversion && npm publish --access public",
     "publish:pre": "npm run preversion && npm publish --access public --tag beta",
     "start": "concurrently '0serve -o demo/prosemirror.html' 'npm run watch'"
   },


### PR DESCRIPTION
## Summary
- rename the custom `publish` script to `publish:manual`
- keep the release workflow publishing through `npm run release`
- avoid npm lifecycle recursion when `npm publish` runs during the release pipeline

## Why
`npm publish` automatically runs the npm `publish` lifecycle script. The repository also defined a custom script named `publish` that called `npm publish` again, which caused the release pipeline to attempt a second publish of the same version and fail after the first publish had already succeeded.