### PR TITLE
fix: add null guard for awareness state in createDecorations

### DIFF
--- a/.changeset/null-check-awareness-state.md
+++ b/.changeset/null-check-awareness-state.md
@@ -1,0 +1,5 @@
+---
+'@tiptap/y-tiptap': patch
+---
+
+Guard against null awareness state values in the cursor plugin so iterating over `awareness.getStates()` after a client disconnects no longer throws a TypeError when accessing `aw.cursor`.

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -95,7 +95,7 @@ export const createDecorations = (
       return
     }
 
-    if (aw.cursor != null) {
+    if (aw && aw.cursor != null) {
       const user = aw.user || {}
       if (user.color == null) {
         user.color = '#ffa500'

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -95,6 +95,8 @@ export const createDecorations = (
       return
     }
 
+    // `aw` can be null when a client disconnects, so we guard against it
+    // before reading `cursor` to avoid a TypeError.
     if (aw && aw.cursor != null) {
       const user = aw.user || {}
       if (user.color == null) {


### PR DESCRIPTION
## Problem

In `createDecorations`, `awareness.getStates().forEach()` iterates over
awareness states, but the state value (`aw`) can be `null` or `undefined`
(e.g. when a client disconnects). Accessing `aw.cursor` without a null
check causes a `TypeError`.

## Solution

Added a null guard (`aw &&`) before accessing `aw.cursor` on line 98 of
`src/plugins/cursor-plugin.js`.