### PR TITLE
fix: remove UndoManager's leaked doc 'destroy' listener on plugin destroy

### DIFF
--- a/.changeset/undo-manager-doc-destroy-leak.md
+++ b/.changeset/undo-manager-doc-destroy-leak.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/y-tiptap": patch
+---
+
+Fix a memory leak in `yUndoPlugin`. Yjs' `UndoManager` registers a `doc.on('destroy', …)` listener in its constructor that `UndoManager.destroy()` never removes. When the Y.Doc outlives the editor (e.g. several editors sharing one provider), that listener kept the `UndoManager` — and everything it referenced — reachable from the doc, leaking memory on every editor destroy. The plugin now removes that listener when its view is destroyed (only for managers it created; a caller-provided `undoManager` is left untouched).

--- a/src/plugins/undo-plugin.js
+++ b/src/plugins/undo-plugin.js
@@ -34,11 +34,26 @@ export const yUndoPlugin = ({ protectedNodes = defaultProtectedNodes, trackedOri
     init: (initargs, state) => {
       // TODO: check if plugin order matches and fix
       const ystate = ySyncPluginKey.getState(state)
-      const _undoManager = undoManager || new UndoManager(ystate.type, {
-        trackedOrigins: new Set([ySyncPluginKey].concat(trackedOrigins)),
-        deleteFilter: (item) => defaultDeleteFilter(item, protectedNodes),
-        captureTransaction: tr => tr.meta.get('addToHistory') !== false
-      })
+      let _undoManager = undoManager
+      if (!_undoManager) {
+        // Y.UndoManager registers a `doc.on('destroy', …)` listener in its
+        // constructor that UndoManager.destroy() never removes. When the doc
+        // outlives the editor (e.g. several editors sharing one provider), that
+        // listener keeps the UndoManager — and everything it references —
+        // reachable from the doc, leaking memory on every editor destroy.
+        // We only own the lifecycle of a manager we create here, so capture the
+        // listener(s) it adds and remove them when the plugin view is destroyed.
+        const doc = ystate.doc
+        const destroyListenersBefore = new Set(doc ? doc._observers.get('destroy') : [])
+        _undoManager = new UndoManager(ystate.type, {
+          trackedOrigins: new Set([ySyncPluginKey].concat(trackedOrigins)),
+          deleteFilter: (item) => defaultDeleteFilter(item, protectedNodes),
+          captureTransaction: tr => tr.meta.get('addToHistory') !== false
+        })
+        const destroyListenersAfter = doc ? doc._observers.get('destroy') : new Set()
+        _undoManager._yTiptapDocDestroyListeners = Array.from(destroyListenersAfter || [])
+          .filter(listener => !destroyListenersBefore.has(listener))
+      }
       return {
         undoManager: _undoManager,
         prevSel: null,
@@ -91,6 +106,13 @@ export const yUndoPlugin = ({ protectedNodes = defaultProtectedNodes, trackedOri
     return {
       destroy: () => {
         undoManager.destroy()
+        // Remove the doc 'destroy' listener Y.UndoManager fails to clean up
+        // (only for managers we created — see state.init above).
+        const leakedDestroyListeners = undoManager._yTiptapDocDestroyListeners
+        if (leakedDestroyListeners && undoManager.doc) {
+          leakedDestroyListeners.forEach(listener => undoManager.doc.off('destroy', listener))
+          undoManager._yTiptapDocDestroyListeners = null
+        }
       }
     }
   }

--- a/tests/y-tiptap.test.js
+++ b/tests/y-tiptap.test.js
@@ -107,6 +107,98 @@ export const testPluginIntegrity = (_tc) => {
 }
 
 /**
+ * Y.UndoManager registers a `doc.on('destroy', …)` listener in its constructor
+ * that UndoManager.destroy() never removes. When the doc outlives the editor
+ * (e.g. several editors sharing one provider), that listener keeps the manager —
+ * and everything it references — reachable, leaking memory on every destroy.
+ * yUndoPlugin must remove that listener when the plugin view is destroyed.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testUndoManagerDocDestroyListenerCleanup = (_tc) => {
+  const ydoc = new Y.Doc()
+  const countDocDestroyListeners = () => {
+    const observers = ydoc._observers.get('destroy')
+    return observers ? observers.size : 0
+  }
+  const baseline = countDocDestroyListeners()
+
+  const view = new EditorView(null, {
+    // @ts-ignore
+    state: EditorState.create({
+      schema,
+      plugins: [
+        ySyncPlugin(ydoc.get('prosemirror', Y.XmlFragment)),
+        yUndoPlugin()
+      ]
+    })
+  })
+  view.dispatch(
+    view.state.tr.insert(
+      0,
+      /** @type {any} */ (
+        schema.node('paragraph', undefined, schema.text('hello world'))
+      )
+    )
+  )
+
+  t.assert(
+    countDocDestroyListeners() > baseline,
+    'UndoManager registered a doc destroy listener'
+  )
+
+  view.destroy()
+
+  t.assert(
+    countDocDestroyListeners() === baseline,
+    'doc destroy listener is removed after view.destroy'
+  )
+}
+
+/**
+ * A caller-provided UndoManager owns its own lifecycle, so yUndoPlugin must not
+ * strip listeners it did not add.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testExternalUndoManagerListenersUntouched = (_tc) => {
+  const ydoc = new Y.Doc()
+  const fragment = ydoc.get('prosemirror', Y.XmlFragment)
+  const externalUndoManager = new Y.UndoManager(fragment)
+  const countDocDestroyListeners = () => {
+    const observers = ydoc._observers.get('destroy')
+    return observers ? observers.size : 0
+  }
+  const withExternal = countDocDestroyListeners()
+
+  const view = new EditorView(null, {
+    // @ts-ignore
+    state: EditorState.create({
+      schema,
+      plugins: [
+        ySyncPlugin(fragment),
+        yUndoPlugin({ undoManager: externalUndoManager })
+      ]
+    })
+  })
+  view.dispatch(
+    view.state.tr.insert(
+      0,
+      /** @type {any} */ (
+        schema.node('paragraph', undefined, schema.text('hello world'))
+      )
+    )
+  )
+  view.destroy()
+
+  // The external manager's listener must still be present after destroy.
+  t.assert(
+    countDocDestroyListeners() === withExternal,
+    'externally-provided UndoManager listeners are left intact'
+  )
+}
+
+/**
  * Test that createDecorations handles missing ySyncPlugin state gracefully.
  *
  * This can happen during editor initialization when the ySyncPlugin state


### PR DESCRIPTION
Yjs' UndoManager registers a `doc.on('destroy', …)` listener in its constructor that UndoManager.destroy() never removes. When the Y.Doc outlives the editor (e.g. several editors sharing one provider), that listener kept the UndoManager — and everything it referenced — reachable from the doc, leaking memory on every editor destroy.

yUndoPlugin now captures the listener(s) added while constructing a manager it owns and removes them in the plugin view's destroy. A caller-provided undoManager is left untouched since the caller owns its lifecycle.