### PR TITLE
Add guard in relativePositionToAbsolutePosition when entry is undefined

### DIFF
--- a/.changeset/bright-peaches-float.md
+++ b/.changeset/bright-peaches-float.md
@@ -2,4 +2,4 @@
 "@tiptap/y-tiptap": patch
 ---
 
-Fix: When recieving undefined from `mapping.get(t)` in `relativePositionToAbsolutePosition` set pos to `0` instead of failing. It fails because position is taken from `nodeSize` on the returned entry, without catching the case of the lookup on `mapping` returning undefined.
+Fix: When recieving null from `mapping.get(t)` or `mapping.get(contentType)` in `relativePositionToAbsolutePosition` return `null` instead of failing. It fails because position is taken from `nodeSize` on the returned entry, without catching the case of the lookup on `mapping` returning null.

--- a/.changeset/bright-peaches-float.md
+++ b/.changeset/bright-peaches-float.md
@@ -2,4 +2,4 @@
 "@tiptap/y-tiptap": patch
 ---
 
-Fix: When recieving null from `mapping.get(t)` or `mapping.get(contentType)` in `relativePositionToAbsolutePosition` return `null` instead of failing. It fails because position is taken from `nodeSize` on the returned entry, without catching the case of the lookup on `mapping` returning null.
+Fixed Recieving null from `mapping.get(t)` or `mapping.get(contentType)` in `relativePositionToAbsolutePosition` return `null` instead of failing. It fails because position is taken from `nodeSize` on the returned entry, without catching the case of the lookup on `mapping` returning null.

--- a/.changeset/bright-peaches-float.md
+++ b/.changeset/bright-peaches-float.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/y-tiptap": patch
+---
+
+Fix: When recieving undefined from `mapping.get(t)` in `relativePositionToAbsolutePosition` set pos to `0` instead of failing. It fails because position is taken from `nodeSize` on the returned entry, without catching the case of the lookup on `mapping` returning undefined.

--- a/src/lib.js
+++ b/src/lib.js
@@ -247,7 +247,7 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
         if (t instanceof Y.XmlText) {
           pos += t._length
         } else {
-          pos += /** @type {any} */ (mapping.get(t)).nodeSize
+          pos += (/** @type {any} */ (mapping.get(t)))?.nodeSize ?? 0
         }
       }
       n = /** @type {Y.Item} */ (n.right)
@@ -271,7 +271,7 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
           if (contentType instanceof Y.XmlText) {
             pos += contentType._length
           } else {
-            pos += /** @type {any} */ (mapping.get(contentType)).nodeSize
+            pos += (/** @type {any} */ (mapping.get(contentType)))?.nodeSize ?? 0
           }
         }
         n = n.right

--- a/src/lib.js
+++ b/src/lib.js
@@ -247,7 +247,11 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
         if (t instanceof Y.XmlText) {
           pos += t._length
         } else {
-          pos += (/** @type {any} */ (mapping.get(t)))?.nodeSize ?? 0
+          const mapped = mapping.get(t)
+          if (mapped == null) {
+            return null
+          }
+          pos += /** @type {any} */ (mapped).nodeSize
         }
       }
       n = /** @type {Y.Item} */ (n.right)
@@ -271,7 +275,11 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
           if (contentType instanceof Y.XmlText) {
             pos += contentType._length
           } else {
-            pos += (/** @type {any} */ (mapping.get(contentType)))?.nodeSize ?? 0
+            const mapped = mapping.get(contentType)
+            if (mapped == null) {
+              return null
+            }
+            pos += /** @type {any} */ (mapped).nodeSize
           }
         }
         n = n.right


### PR DESCRIPTION
Hello!

**Original issue with repro steps in tiptap:** https://github.com/ueberdosis/tiptap/issues/7556 (opened by my colleague)
The issue is not solved as of tiptap v3.23.6
**Issue in this repo:** https://github.com/ueberdosis/y-tiptap/issues/33
**Change in this PR:** When recieving undefined from `mapping.get(t)` in `relativePositionToAbsolutePosition` set pos to `0` instead of failing. It fails because position is taken from `nodeSize` on the returned entry, without catching the case of the lookup on `mapping` returning undefined.

We have been running this as a patch in our production environment for a few months and as a fix it works well in our use case. We figured we should make a PR for it.

Happy to answer any questions, take feedback or make changes!

AI disclosure - Github copilot helped me make the original patch and make the changes in this repo.