### PR TITLE
fix: fix node-range-selections being dropped on collaborative changes

### DIFF
--- a/.changeset/restore-node-range-selection.md
+++ b/.changeset/restore-node-range-selection.md
@@ -2,4 +2,4 @@
 "@tiptap/y-tiptap": patch
 ---
 
-Fix duplicated blocks when dragging with the drag handle during collaborative editing. Node range selections are now preserved across remote updates instead of being reset, so dropping a block moves it instead of leaving a copy behind.
+Fix duplicated blocks when dragging with the drag handle during collaborative editing. Node range selections are now preserved across remote updates instead of being reset, so dropping a block moves it instead of leaving a copy behind. Also hardens node selection restore so a remote update that removes the selected node can no longer throw.

--- a/.changeset/restore-node-range-selection.md
+++ b/.changeset/restore-node-range-selection.md
@@ -1,0 +1,5 @@
+---
+"@tiptap/y-tiptap": patch
+---
+
+Fix duplicated blocks when dragging with the drag handle during collaborative editing. Node range selections are now preserved across remote updates instead of being reset, so dropping a block moves it instead of leaving a copy behind.

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -4,7 +4,7 @@
 
 import { createMutex } from 'lib0/mutex'
 import * as PModel from 'prosemirror-model'
-import { AllSelection, Plugin, TextSelection, NodeSelection } from "prosemirror-state"; // eslint-disable-line
+import { AllSelection, Plugin, Selection, TextSelection, NodeSelection } from "prosemirror-state"; // eslint-disable-line
 import * as math from 'lib0/math'
 import * as object from 'lib0/object'
 import * as set from 'lib0/set'
@@ -258,6 +258,23 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         binding.mapping
       )
       tr.setSelection(createSafeNodeSelection(tr, anchor))
+    } else if (relSel.type === 'nodeRange') {
+      const anchor = relativePositionToAbsolutePosition(
+        binding.doc,
+        binding.type,
+        relSel.anchor,
+        binding.mapping
+      )
+      const head = relativePositionToAbsolutePosition(
+        binding.doc,
+        binding.type,
+        relSel.head,
+        binding.mapping
+      )
+      const selection = createSafeNodeRangeSelection(tr, anchor, head, relSel.depth)
+      if (selection !== null) {
+        tr.setSelection(selection)
+      }
     } else {
       const anchor = relativePositionToAbsolutePosition(
         binding.doc,
@@ -296,22 +313,61 @@ const createSafeNodeSelection = (tr, pos) => {
 }
 
 /**
+ * @param {import('prosemirror-state').Transaction} tr
+ * @param {number|null} anchor
+ * @param {number|null} head
+ * @param {number|undefined} depth
+ * @returns {import('prosemirror-state').Selection|null}
+ *
+ * Reconstructs a NodeRangeSelection (registered by `@tiptap/extension-node-range`
+ * via `Selection.jsonID('nodeRange', …)`) from absolute positions, without taking a
+ * dependency on that package. Falls back to a TextSelection if the range is empty or
+ * the selection type is not registered.
+ */
+const createSafeNodeRangeSelection = (tr, anchor, head, depth) => {
+  if (anchor === null || head === null) {
+    return null
+  }
+  const clampedAnchor = Math.min(Math.max(anchor, 0), tr.doc.content.size)
+  const clampedHead = Math.min(Math.max(head, 0), tr.doc.content.size)
+  try {
+    const selection = Selection.fromJSON(tr.doc, {
+      type: 'nodeRange',
+      anchor: clampedAnchor,
+      head: clampedHead,
+      depth
+    })
+    if (!selection.ranges.length) {
+      return TextSelection.near(tr.doc.resolve(clampedAnchor))
+    }
+    return selection
+  } catch (e) {
+    return TextSelection.near(tr.doc.resolve(clampedAnchor))
+  }
+}
+
+/**
  * @param {ProsemirrorBinding} pmbinding
  * @param {import('prosemirror-state').EditorState} state
  */
-export const getRelativeSelection = (pmbinding, state) => ({
-  type: /** @type {any} */ (state.selection).jsonID,
-  anchor: absolutePositionToRelativePosition(
-    state.selection.anchor,
-    pmbinding.type,
-    pmbinding.mapping
-  ),
-  head: absolutePositionToRelativePosition(
-    state.selection.head,
-    pmbinding.type,
-    pmbinding.mapping
-  )
-})
+export const getRelativeSelection = (pmbinding, state) => {
+  const type = /** @type {any} */ (state.selection).jsonID
+  return {
+    type,
+    // `depth` is only meaningful for NodeRangeSelection; undefined for every other type.
+    depth: type === 'nodeRange' ? /** @type {any} */ (state.selection).depth : undefined,
+    anchor: absolutePositionToRelativePosition(
+      state.selection.anchor,
+      pmbinding.type,
+      pmbinding.mapping
+    ),
+    head: absolutePositionToRelativePosition(
+      state.selection.head,
+      pmbinding.type,
+      pmbinding.mapping
+    )
+  }
+}
 
 /**
  * Binding for prosemirror.

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -257,7 +257,11 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         relSel.anchor,
         binding.mapping
       )
-      tr.setSelection(createSafeNodeSelection(tr, anchor))
+      // anchor is null when the referenced node was deleted or moved out of
+      // binding.type by a remote update; resolving null would throw.
+      if (anchor !== null) {
+        tr.setSelection(createSafeNodeSelection(tr, anchor))
+      }
     } else if (relSel.type === 'nodeRange') {
       const anchor = relativePositionToAbsolutePosition(
         binding.doc,

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -317,16 +317,19 @@ const createSafeNodeSelection = (tr, pos) => {
 }
 
 /**
- * @param {import('prosemirror-state').Transaction} tr
- * @param {number|null} anchor
- * @param {number|null} head
- * @param {number|undefined} depth
- * @returns {import('prosemirror-state').Selection|null}
+ * Safely reconstructs a NodeRangeSelection from resolved absolute positions.
  *
- * Reconstructs a NodeRangeSelection (registered by `@tiptap/extension-node-range`
- * via `Selection.jsonID('nodeRange', …)`) from absolute positions, without taking a
- * dependency on that package. Falls back to a TextSelection if the range is empty or
- * the selection type is not registered.
+ * @param {import('prosemirror-state').Transaction} tr - The transaction whose document provides resolved positions.
+ * @param {number|null} anchor - Absolute document position marking the start (boundary) of the node range.
+ *        Use `relativePositionToAbsolutePosition` before calling this function.
+ * @param {number|null} head - Absolute document position marking the end (boundary) of the node range.
+ *        Use `relativePositionToAbsolutePosition` before calling this function.
+ * @param {number|undefined} depth - The nesting depth at which the range operates (e.g. 0 for
+ *        top-level blocks, 1 for blocks nested inside a wrapper). Passed through to
+ *        `Selection.fromJSON`; ignored by `@tiptap/extension-node-range` < v2.29 but
+ *        properly stored starting from that version.
+ * @returns {import('prosemirror-state').Selection|null} Reconstructed selection, or null if
+ *          anchor/head could not be resolved.
  */
 const createSafeNodeRangeSelection = (tr, anchor, head, depth) => {
   if (anchor === null || head === null) {

--- a/tests/y-tiptap.test.js
+++ b/tests/y-tiptap.test.js
@@ -23,6 +23,7 @@ import { Awareness } from 'y-protocols/awareness'
 import {
   EditorState,
   Plugin,
+  Selection,
   TextSelection,
   NodeSelection
 } from 'prosemirror-state'
@@ -48,6 +49,48 @@ const schema = new Schema({
     }
   })
 })
+
+/**
+ * Minimal stand-in for the `NodeRangeSelection` that `@tiptap/extension-node-range`
+ * registers via `Selection.jsonID('nodeRange', …)`. y-tiptap reconstructs node range
+ * selections through ProseMirror's selection registry (`Selection.fromJSON`) rather than
+ * importing the extension, so registering this here lets us exercise that code path.
+ */
+class NodeRangeSelection extends Selection {
+  /**
+   * @param {import('prosemirror-model').ResolvedPos} $anchor
+   * @param {import('prosemirror-model').ResolvedPos} $head
+   * @param {number} depth
+   */
+  constructor ($anchor, $head, depth) {
+    super($anchor, $head)
+    this.depth = depth
+  }
+
+  map (doc, mapping) {
+    return new NodeRangeSelection(
+      doc.resolve(mapping.map(this.anchor)),
+      doc.resolve(mapping.map(this.head)),
+      this.depth
+    )
+  }
+
+  eq (other) {
+    return other instanceof NodeRangeSelection &&
+      other.anchor === this.anchor &&
+      other.head === this.head &&
+      other.depth === this.depth
+  }
+
+  toJSON () {
+    return { type: 'nodeRange', anchor: this.anchor, head: this.head, depth: this.depth }
+  }
+
+  static fromJSON (doc, json) {
+    return new NodeRangeSelection(doc.resolve(json.anchor), doc.resolve(json.head), json.depth)
+  }
+}
+Selection.jsonID('nodeRange', NodeRangeSelection)
 
 /**
  * Verify that update events in plugins are only fired once.
@@ -1035,6 +1078,64 @@ export const testRestoreSelectionForDeletedBlockNode = async (_tc) => {
   t.assert(
     sel instanceof NodeSelection,
     'selection should be a NodeSelection for block node'
+  )
+}
+
+/**
+ * A NodeRangeSelection (e.g. an active drag-handle drag) must survive a remote Yjs
+ * update instead of being downgraded to a TextSelection. Regression test for TT-608,
+ * where the downgrade caused collaborative drags to duplicate the dragged block.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testRestoreNodeRangeSelectionOnRemoteUpdate = (_tc) => {
+  const ydoc1 = new Y.Doc()
+  ydoc1.clientID = 1
+  const ydoc2 = new Y.Doc()
+  ydoc2.clientID = 2
+  const view1 = createNewProsemirrorView(ydoc1)
+  const view2 = createNewProsemirrorView(ydoc2)
+
+  // three top-level paragraphs, authored on peer 1
+  view1.dispatch(
+    view1.state.tr.insert(0, [
+      schema.node('paragraph', undefined, schema.text('one')),
+      schema.node('paragraph', undefined, schema.text('two')),
+      schema.node('paragraph', undefined, schema.text('three'))
+    ])
+  )
+  // sync both peers to the same content
+  Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1))
+  Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2))
+
+  // peer 1 selects a range of block nodes (paragraphs 1 + 2) at depth 0
+  const doc1 = view1.state.doc
+  const head = doc1.child(0).nodeSize + doc1.child(1).nodeSize
+  view1.dispatch(
+    view1.state.tr.setSelection(
+      new NodeRangeSelection(doc1.resolve(0), doc1.resolve(head), 0)
+    )
+  )
+  t.assert(
+    view1.state.selection instanceof NodeRangeSelection,
+    'precondition: peer 1 holds a NodeRangeSelection'
+  )
+
+  // peer 2 makes an inline edit in the last paragraph (a concurrent remote change)
+  const editPos = view2.state.doc.content.size - 1
+  view2.dispatch(view2.state.tr.insertText('!', editPos, editPos))
+
+  // deliver peer 2's change to peer 1 -> triggers restoreRelativeSelection on peer 1
+  Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2))
+
+  const sel = view1.state.selection
+  t.assert(
+    sel instanceof NodeRangeSelection,
+    'NodeRangeSelection should be preserved across a remote update, not downgraded'
+  )
+  t.assert(
+    /** @type {any} */ (sel).depth === 0,
+    'the selection depth should be preserved'
   )
 }
 


### PR DESCRIPTION
This pull request fixes an issue where dragging blocks with the drag handle in collaborative editing could result in duplicated blocks. The main improvement is that node range selections are now correctly preserved across remote updates, ensuring that moving a block works as expected instead of leaving a copy behind. The changes also add robust handling and testing for node range selections.

**Collaborative editing improvements:**

* Node range selections are now preserved across remote updates, preventing them from being reset and avoiding block duplication when dragging with the drag handle. [[1]](diffhunk://#diff-e5eb91ed30d599e97a98a4e72cc51dcf3b030393dc0fce6deec8284005ec689eR1-R5) [[2]](diffhunk://#diff-e5d90c73c652deda2a5a899077b103598fcb7eed0d91f0bea4e7207389d58c5fR261-R277)
* Added a safe reconstruction method for node range selections (`createSafeNodeRangeSelection`) that falls back gracefully if the selection type is unavailable.

**Testing enhancements:**

* Introduced a minimal `NodeRangeSelection` class in tests to simulate the behavior of the real extension and allow for thorough testing of node range selection restoration.
* Added a regression test to ensure node range selections survive remote Yjs updates, verifying that collaborative drags do not duplicate blocks.

**Internal code improvements:**

* Refactored selection handling logic to support the new node range selection type, including updates to how relative selections are tracked and restored. [[1]](diffhunk://#diff-e5d90c73c652deda2a5a899077b103598fcb7eed0d91f0bea4e7207389d58c5fL7-R7) [[2]](diffhunk://#diff-e5d90c73c652deda2a5a899077b103598fcb7eed0d91f0bea4e7207389d58c5fL314-R370) [[3]](diffhunk://#diff-c415f6f8eb3802df183abb2e6da70efdf2edb2cfc38deed72a54864c2e153ed3R26)